### PR TITLE
refactored to use clicks, not mouseovers

### DIFF
--- a/src/components/Gene.js
+++ b/src/components/Gene.js
@@ -163,22 +163,23 @@ export default class Gene extends Component {
     );
 
     const tooltip = this.props.tooltip
-      ? <Tooltip id="tooltip">{ this.props.tooltip }</Tooltip>
+      ?  <Tooltip id="tooltip">{ this.props.tooltip }</Tooltip>
       : null;
 
 		return (
-    <OverlayTrigger placement={ this.props.tooltipPlacement } overlay={tooltip}>
-      <g transform={"translate(" + (this.props.gene.orientation == '+' ? 0 : this.props.x * 2 + this.props.width) + ",0) scale(" + (this.props.gene.orientation == '+' ? 1 : -1) + ",1)"}>
-        <path d={d} fill = {this.props.fillColor}
-          strokeWidth = { this.strokeWidth(this.props.highlighted, this.props.highlightWidth) }
-          stroke = { this.stroke(this.props.highlighted, this.props.highlightColor, this.props.strokeColor) }
-          onClick= { this.handleClick }
-          opacity = { this.props.opacity }
-          onMouseOver = { this.tooltipOver.bind(this) }
-          onMouseOut  = { this.tooltipOut.bind(this) }
-          mask = {shapeStuff.mask ? shapeStuff.mask() : ''}
-          />
-      </g>
+      <OverlayTrigger placement={ this.props.tooltipPlacement } overlay={tooltip} trigger='click' rootClose={true}>
+        <g transform={"translate(" + (this.props.gene.orientation == '+' ? 0 : this.props.x * 2 + this.props.width) + ",0) scale(" + (this.props.gene.orientation == '+' ? 1 : -1) + ",1)"}>
+          <path d={d} fill = {this.props.fillColor}
+            strokeWidth = { this.strokeWidth(this.props.highlighted, this.props.highlightWidth) }
+            stroke = { this.stroke(this.props.highlighted, this.props.highlightColor, this.props.strokeColor) }
+            //onClick= { this.handleClick }
+            //onDoubleClick={ this.handleClick }
+            opacity = { this.props.opacity }
+            //onMouseOver = { this.tooltipOver.bind(this) }
+            //onMouseOut  = { this.tooltipOut.bind(this) }
+            mask = {shapeStuff.mask ? shapeStuff.mask() : ''}
+            />
+        </g>
       </OverlayTrigger>
 
 		);

--- a/src/components/Neighborhood.jsx
+++ b/src/components/Neighborhood.jsx
@@ -9,6 +9,8 @@ var d3Scale = require('d3-scale');
 const neighborhoodHeight = 24;
 const scaleFactor = 20;
 
+const syntenyURL = 'http://ensembl.gramene.org/Oryza_sativa/Location/Synteny?r=';
+
 const NeighborhoodArrow = props => {
   const arrowLength = scaleFactor * 10*props.totalLength/props.width;
   const arrowHeight = 4;
@@ -34,19 +36,19 @@ const NeighborhoodArrow = props => {
       ['end', props.neighborhood.region.end]
     ];
     tooltip = (
-      <Tooltip id="tooltip">
-      <table>
-        <tbody>
-        {tooltipFields.map( (tip, i ) => {
-          return (
-            <tr key = {i} style={{verticalAlign : 'top'}}>
-              <th>{tip[0]}</th>
-              <td style={{color : 'lightgray'}}>{tip[1]}</td>
-            </tr>
-          )
-        })}
-        </tbody>
-      </table>
+      <Tooltip>
+        <table>
+          <tbody>
+          {tooltipFields.map( (tip, i ) => {
+            return (
+              <tr key = {i} style={{verticalAlign : 'top'}}>
+                <th>{tip[0]}</th>
+                <td style={{color : 'lightgray', textAlign : 'left', paddingLeft : '15px'}}>{tip[1]}</td>
+              </tr>
+            )
+          })}
+          </tbody>
+        </table>
       </Tooltip>
     );
   }
@@ -92,15 +94,26 @@ const ComparaGene = props => {
 
   const identity = gene.relationToGeneOfInterest ? gene.relationToGeneOfInterest.identity : 1;
 
+  const highlighted = props.highlighted[gene.tree_id];
+
   let tooltipFields = [
-    ['Gene ID',     gene.id],
+    ['Gene IDZZZ',     gene.id],
     ['Gene Name',   gene.name],
     // ['Taxonomy',    props.taxonomy.taxonIdToSpeciesName[gene.taxon_id]],
-    ['Region',      `${gene.region}:${gene.start}-${gene.end}:${gene.orientation}`],
+    ['Region',      <a href = {`${syntenyURL}${gene.region}:${gene.start}-${gene.end}:${gene.orientation}`} target='_blank'>{`${gene.region}:${gene.start}-${gene.end}:${gene.orientation}`}</a>],
     ['Tree ID',     gene.tree_id],
     //['Tree Root',   this.props.taxonomy.taxonIdToSpeciesName[gene.gene_tree_root_taxon_id]],
     ['Biotype',     gene.biotype],
-    ['Description', gene.description]
+    ['Description', gene.description],
+    ['', (
+      <button className='btn btn-xs btn-default' onClick={() => {
+        if (props.clickHandler) {
+          props.clickHandler(gene.id, gene.tree_id)
+        }
+      }}>
+        {highlighted ? 'Unhighlight' : 'Highlight'} this gene tree
+      </button>
+    )]
   ];
   if (gene.relationToGeneOfInterest) {
     tooltipFields.push(['Identity',Math.floor(1000*identity)/10 + '%']);
@@ -113,7 +126,7 @@ const ComparaGene = props => {
           return (
             <tr key = {i} style={{verticalAlign : 'top'}}>
               <th>{tip[0]}</th>
-              <td style={{color : 'lightgray'}}>{tip[1]}</td>
+              <td style={{color : 'lightgray', textAlign : 'left', paddingLeft : '15px'}}>{tip[1]}</td>
             </tr>
           )
         })}
@@ -129,8 +142,6 @@ const ComparaGene = props => {
         strokeWidth="1"
       />
     : null;
-
-  const highlighted = props.highlighted[gene.tree_id];
 
   return (
     <g>

--- a/src/components/Neighborhood.jsx
+++ b/src/components/Neighborhood.jsx
@@ -30,10 +30,12 @@ const NeighborhoodArrow = props => {
     const points = `${tipX},${tipY} ${tailX},${tipY + arrowHeight} ${tailX},${tipY - arrowHeight}`;
     color = props.neighborhood.region.color;
     arrowHead = <polygon points={points} stroke={color} fill={color}/>
+    const region = props.neighborhood.region;
     let tooltipFields = [
-      ['region', props.neighborhood.region.name],
-      ['start', props.neighborhood.region.start],
-      ['end', props.neighborhood.region.end]
+      ['region', region.name],
+      ['start', region.start],
+      ['end', region.end],
+      ['',<a href = {`${syntenyURL}${region.name}:${region.start}-${region.end}`} target='_blank'>{`Synteny browser`}</a>]
     ];
     tooltip = (
       <Tooltip>
@@ -67,7 +69,7 @@ const NeighborhoodArrow = props => {
   }
   return (
     <g>
-      <OverlayTrigger placement="left" overlay={tooltip}>
+      <OverlayTrigger placement="left" overlay={tooltip} trigger='click' rootClose={true}>
       <line
         x1={lineStart} y1={neighborhoodHeight / 2}
         x2={lineEnd} y2={neighborhoodHeight / 2}
@@ -97,13 +99,13 @@ const ComparaGene = props => {
   const highlighted = props.highlighted[gene.tree_id];
 
   let tooltipFields = [
-    ['Gene IDZZZ',     gene.id],
+    ['Gene ID',     <a href={`http://www.gramene.org?idList=${gene.id}`} target='_blank'>{gene.id}</a>],
     ['Gene Name',   gene.name],
     // ['Taxonomy',    props.taxonomy.taxonIdToSpeciesName[gene.taxon_id]],
     ['Region',      <a href = {`${syntenyURL}${gene.region}:${gene.start}-${gene.end}:${gene.orientation}`} target='_blank'>{`${gene.region}:${gene.start}-${gene.end}:${gene.orientation}`}</a>],
     ['Tree ID',     gene.tree_id],
     //['Tree Root',   this.props.taxonomy.taxonIdToSpeciesName[gene.gene_tree_root_taxon_id]],
-    ['Biotype',     gene.biotype],
+    // ['Biotype',     gene.biotype],
     ['Description', gene.description],
     ['', (
       <button className='btn btn-xs btn-default' onClick={() => {

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,7 @@ body {
   padding: 0;
   font-family: sans-serif;
 }
+
+.tooltip-inner {
+  max-width : 400px;
+}


### PR DESCRIPTION
This does a couple of things -

* it fixes the size of the popup to (hopefully) include all relevant data. As is it could slide off the right edge
* It redefines the mouseovers on the boats to be clicks, and adds in a highlight/unhighlight button in the popover. The prior functionality was to highlight by clicking, and get the popup on mouseover.
* It adds a link to the synteny browser by clicking on the region in the popup of the gene.